### PR TITLE
fixed initialization of flux variable problem

### DIFF
--- a/branching_udfs.c
+++ b/branching_udfs.c
@@ -195,6 +195,7 @@ DEFINE_EXECUTE_AT_END(renew_vol_pat_a)
 
   Domain *domain;
   real total_flux, volume, old_flux, timestep;
+  total_flux = 0.0;
   int surface_thread_id, iprop;
   fid = fopen("pat_a_inlet_id", "r");
   //reading the surface id and the flow variable id
@@ -250,6 +251,7 @@ DEFINE_EXECUTE_AT_END(renew_vol_pat_b)
 
   Domain *domain;
   real total_flux, volume, old_flux, timestep;
+  total_flux = 0.0;
   int surface_thread_id, iprop;
   fid = fopen("pat_b_inlet_id", "r");
   //reading the surface id and the flow variable id


### PR DESCRIPTION
total_flux variables for both patients had not been initialized at DEFINE-EXECUTE-AT-END udfs.